### PR TITLE
Add a helper for markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,4 @@ script:
   - cargo $TASK --no-default-features --features no_logging --verbose
   - cargo $TASK --no-default-features --features dir_source --verbose
   - cargo $TASK --no-default-features --features script_helper --verbose
+  - cargo $TASK --no-default-features --features markdown_helpers --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,11 @@ serde_json = "1.0.39"
 num-order = "1.2.0"
 walkdir = { version = "2.2.3", optional = true }
 rhai = { version = "1.16.1", optional = true, features = ["sync", "serde"] }
-rust-embed = { version = "8.0.0", optional = true, features = ["include-exclude"] }
+rust-embed = { version = "8.0.0", optional = true, features = [
+    "include-exclude",
+] }
 heck = { version = "0.5", optional = true }
+markdown = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"
@@ -41,7 +44,8 @@ serde_derive = "1.0.75"
 tempfile = "3.0.0"
 criterion = "0.6"
 tiny_http = "0.12"
-time = { version = "0.3.7", features = ["serde", "formatting", "parsing"]}
+time = { version = "0.3.7", features = ["serde", "formatting", "parsing"] }
+rstest = { version = "0.25.0" }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.15", features = ["flamegraph", "prost-codec"] }
@@ -52,6 +56,8 @@ script_helper = ["rhai"]
 no_logging = []
 default = []
 string_helpers = ["heck"]
+markdown_helpers = ["dep:markdown"]
+markdown_fmt_default = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,9 @@ pub enum RenderErrorReason {
     Unimplemented,
     #[error("{0}")]
     Other(String),
+    #[cfg(feature = "markdown_helpers")]
+    #[error(r#"Failed to process markdown "{0}": {1}"#)]
+    MarkdownError(String, markdown::message::Message),
 }
 
 impl From<RenderErrorReason> for RenderError {

--- a/src/helpers/helper_markdown.rs
+++ b/src/helpers/helper_markdown.rs
@@ -25,10 +25,8 @@ pub fn helper_markdown(
     for param in h.params().iter() {
         let markdown = param.value().render();
         out.write(
-            &markdown::to_html_with_options(&markdown, &options).map_err(|e| {
-                eprintln!("------> {markdown} error {}", e);
-                RenderErrorReason::MarkdownError(markdown, e)
-            })?,
+            &markdown::to_html_with_options(&markdown, &options)
+                .map_err(|e| RenderErrorReason::MarkdownError(markdown, e))?,
         )?;
     }
 

--- a/src/helpers/helper_markdown.rs
+++ b/src/helpers/helper_markdown.rs
@@ -1,0 +1,98 @@
+use crate::{
+    Context, Handlebars, Helper, HelperResult, JsonRender, Output, RenderContext, RenderErrorReason,
+};
+
+///
+/// Markdown helper im[plementration which converts markdown text into html, accepts
+/// multiple parameters and processes them all.
+///
+/// Examples:
+/// `{{markdown '# heading one' }}`
+/// `{{markdonwn todo.content }}`
+///
+pub fn helper_markdown(
+    h: &Helper<'_>,
+    _handlebars: &Handlebars<'_>,
+    _context: &Context,
+    _rc: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> HelperResult {
+    #[cfg(not(feature = "markdown_fmt_default"))]
+    let options = markdown::Options::gfm();
+    #[cfg(feature = "markdown_fmt_default")]
+    let options = markdown::Options::default();
+
+    for param in h.params().iter() {
+        let markdown = param.value().render();
+        out.write(
+            &markdown::to_html_with_options(&markdown, &options).map_err(|e| {
+                eprintln!("------> {markdown} error {}", e);
+                RenderErrorReason::MarkdownError(markdown, e)
+            })?,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::Value;
+
+    #[rstest]
+    #[case::simple_header(
+        "{{markdown header}}",
+        json!({"header": "# header one"}),
+        "<h1>header one</h1>"
+    )]
+    #[case::simple_content(
+        "{{markdown content}}",
+        json!({"content": "- item one\n- item two"}),
+        "<ul><li>item one</li><li>item two</li></ul>"
+    )]
+    #[case::mulitple_arguments(
+        "{{markdown header content}}",
+        json!({
+            "header": "## header",
+            "content": "- item one\n- item two"
+        }),
+        "<h2>header</h2><ul><li>item one</li><li>item two</li></ul>"
+    )]
+    #[case::inline_values(
+        "{{markdown '# header'}}",
+        json!({}),
+        "<h1>header</h1>"
+    )]
+    #[case::mixed_values(
+        "{{markdown header '`code`'}}",
+        json!({
+            "header": "## header",
+        }),
+        "<h2>header</h2><p><code>code</code></p>"
+    )]
+    #[case::html_tags_escaped(
+        "{{markdown '<b>x</b>'}}",
+        json!({}),
+        "<p>&lt;b&gt;x&lt;/b&gt;</p>"
+    )]
+    #[cfg_attr(feature = "markdown_fmt_default", case::todolist_default(
+        "{{markdown '- [x] finished item' }}",
+        json!({}),
+        "<ul><li>[x] finished item</li></ul>"
+    ))]
+    #[cfg_attr(not(feature = "markdown_fmt_default"), case::parse_todolist_gfm(
+        "{{markdown '- [x] finished item'}}",
+        json!({}),
+        r#"<ul><li><input type="checkbox" disabled="" checked=""/>finished item</li></ul>"#
+    ))]
+    fn markdown_helper(#[case] template: &str, #[case] data: Value, #[case] html: &str) {
+        let hbs = crate::registry::Registry::new();
+        let result = hbs.render_template(template, &data).unwrap();
+        // for comparison strip whitespace
+        assert_eq!(
+            html.replace(['\n', ' ', '\t'], ""),
+            result.replace(['\n', ' ', '\t'], "")
+        );
+    }
+}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -12,6 +12,9 @@ pub use self::helper_lookup::LOOKUP_HELPER;
 pub use self::helper_raw::RAW_HELPER;
 pub use self::helper_with::WITH_HELPER;
 
+#[cfg(feature = "markdown_helpers")]
+pub mod helper_markdown;
+
 /// A type alias for `Result<(), RenderError>`
 pub type HelperResult = Result<(), RenderError>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,30 @@
 //! # }
 //! # }
 //! ```
+//! ### Markdown Helper
+//!
+//! Markdown support in [Handlebars] is available via the `markdown_helpers` feature.
+//! By default, this uses [GitHub Flavored Markdown](https://github.github.com/gfm/),
+//! but you can switch to [CommonMark](https://spec.commonmark.org/) by enabling the
+//! optional `markdown_fmt_default` feature.
+//!
+//! This functionality is powered by the [`markdown-rs`](https://github.com/wooorm/markdown-rs) crate.
+//! ```
+//! # #[cfg(feature = "markdown_helpers")] {
+//! use handlebars::Handlebars;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut handlebars = Handlebars::new();
+//!
+//! let data = serde_json::json!({"value": "# header text"});
+//! assert_eq!(
+//!   handlebars.render_template("This is {{markdown value}}", &data)?,
+//!   "<h1>header text</h1>".to_owned()
+//! );
+//! # Ok(())
+//! # }
+//! # }
+//! ```
 //!
 
 #![allow(dead_code, clippy::upper_case_acronyms)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -186,6 +186,12 @@ impl<'reg> Registry<'reg> {
         self.register_helper("not", Box::new(helpers::helper_extras::not));
         self.register_helper("len", Box::new(helpers::helper_extras::len));
 
+        #[cfg(feature = "markdown_helpers")]
+        self.register_helper(
+            "markdown",
+            Box::new(helpers::helper_markdown::helper_markdown),
+        );
+
         #[cfg(feature = "string_helpers")]
         self.register_string_helpers();
 
@@ -948,9 +954,18 @@ mod test {
         let string_helpers = 8;
         #[cfg(not(feature = "string_helpers"))]
         let string_helpers = 0;
+        #[cfg(feature = "markdown_helpers")]
+        let markdown_helpers = 1;
+        #[cfg(not(feature = "markdown_helpers"))]
+        let markdown_helpers = 0;
+
         assert_eq!(
             r.helpers.len(),
-            num_helpers + num_boolean_helpers + num_custom_helpers + string_helpers
+            num_helpers
+                + num_boolean_helpers
+                + num_custom_helpers
+                + string_helpers
+                + markdown_helpers
         );
     }
 


### PR DESCRIPTION
this adds a feature `markdown_helpers` which provides a helper for handling markdown text which is enabled by default when the feature is enabled.

The feature `markdown_fmt_default` can be used toggle to the CommonMark specification instead of the GitHub one.